### PR TITLE
Remove Multidex usages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,4 @@ dependencies {
     testImplementation(libs.coroutines.test)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.robolectric)
-
-    testImplementation("org.robolectric:shadows-multidex:3.0")
 }


### PR DESCRIPTION
Since the min SDK is 24, it is no longer necessary to use the Multidex library. In particular, here you're using a Robolectric-specific library without having Multidex enabled on the app itself.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l